### PR TITLE
Upgrade setuptools to 78.1.1 to fix path traversal vulnerability in PackageIndex.download

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     # setuptools 77.0.3+ supports PEP 639
-    "setuptools>=77.0.3,<=80.9.0",
+    # setuptools 78.1.1 fix path traversal vulnerability
+    "setuptools>=78.1.1,<=80.9.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
https://github.com/pypa/setuptools/security/advisories/GHSA-5rjg-fvgr-3xxf